### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 test.ps1
+temp_creds.xml
+test2.ps1

--- a/EMA-Autotask.psm1
+++ b/EMA-Autotask.psm1
@@ -345,6 +345,7 @@ function Invoke-EmaSyncCompaniesExperimental {
             #Find Activated devices count for mapped products
             $ActivatedDevicesPerServiceCount = @{}
 
+
             foreach ($Product in $Mappings.ProductServiceMappings) {
                 
                 #Get Count of activated devices for this product
@@ -353,19 +354,22 @@ function Invoke-EmaSyncCompaniesExperimental {
                 Write-Host("Number of activated " + $EsetProductName + ": " + $FilteredActivatedDevices.Count)
                 #Store Activated devices in relevant service for later use
                 $AutotaskServiceId = $Product.AutotaskServiceId
-                $ActivatedDevicesPerServiceCount.$AutotaskServiceId += $FilteredActivatedDevices.Count
-                #$ActivatedDevicesPerServiceCount
+                #Only fill hashtable if there are activated endpoints
+                if ($FilteredActivatedDevices.Count -ne 0) {
+                    $ActivatedDevicesPerServiceCount.$AutotaskServiceId += $FilteredActivatedDevices.Count                    
+                }
             }
 
             #Check if Autotask Contracts need updating:
             foreach ($ServiceId in $ActivatedDevicesPerServiceCount.Keys) {
                 
                 Write-Host("Comparing count in autoTask") -foregroundColor Cyan
-                Write-Host("ContractId :" + $ContractID.AutoTaskContractID + " ServiceID:" + $ServiceId)
+                Write-Host("ContractId :" + $ContractID.AutoTaskContractID + " ServiceID: " + $ServiceId)
                 $AutotaskUnits = Get-AutotaskContractServiceUnits -ContractID $ContractID.autoTaskContractID -serviceID $ServiceId
                 
                 if ($null -ne $AutotaskUnits) {
                     $Adjustment = ($ActivatedDevicesPerServiceCount[$ServiceId] - $AutotaskUnits.units)
+                    $AutotaskUnitds
                     Write-Host("ESET Count: " + $ActivatedDevicesPerServiceCount[$ServiceId] + " Autotask Count: " + $AutotaskUnits.units)
                     if ($ActivatedDevicesPerServiceCount[$ServiceId] -gt $AutotaskUnits.units) {
                         Write-Host("ESET Count higher than Autotask, adjustment to make: " + $Adjustment)

--- a/EMA-Autotask.psm1
+++ b/EMA-Autotask.psm1
@@ -361,7 +361,7 @@ function Invoke-EmaSyncCompaniesExperimental {
             foreach ($ServiceId in $ActivatedDevicesPerServiceCount.Keys) {
                 
                 Write-Host("Comparing count in autoTask") -foregroundColor Cyan
-                Write-Host("ContractId :" + $ContractID.AutoTaskContractID + " ServiceID :" + $ServiceId)
+                Write-Host("ContractId :" + $ContractID.AutoTaskContractID + " ServiceID:" + $ServiceId)
                 $AutotaskUnits = Get-AutotaskContractServiceUnits -ContractID $ContractID.autoTaskContractID -serviceID $ServiceId
                 
                 if ($null -ne $AutotaskUnits) {

--- a/EMA-Autotask.psm1
+++ b/EMA-Autotask.psm1
@@ -366,6 +366,7 @@ function Invoke-EmaSyncCompaniesExperimental {
                 
                 if ($null -ne $AutotaskUnits) {
                     $Adjustment = ($ActivatedDevicesPerServiceCount[$ServiceId] - $AutotaskUnits.units)
+                    Write-Host("ESET Count: " + $ActivatedDevicesPerServiceCount[$ServiceId] + " Autotask Count: " + $AutotaskUnits.units)
                     if ($ActivatedDevicesPerServiceCount[$ServiceId] -gt $AutotaskUnits.units) {
                         Write-Host("ESET Count higher than Autotask, adjustment to make: " + $Adjustment)
                         if (!$DryRun) {
@@ -373,7 +374,7 @@ function Invoke-EmaSyncCompaniesExperimental {
                             Set-AutotaskContractServiceadjustments -ServiceID $Service -ContractID $ContractID.autoTaskContractID -unitChange $Adjustment
                         }
                     }
-                    if ($ActivatedDevicesPerServiceCount[$Service] -lt $AutotaskUnits.units) {
+                    if ($ActivatedDevicesPerServiceCount[$ServiceId] -lt $AutotaskUnits.units) {
                         Write-Host("ESET Count lower than Autotask, adjustment to make: " + $Adjustment)
                         if (!$DryRun) {
                             if ($AutotaskUnits.units -eq 1) {
@@ -384,7 +385,7 @@ function Invoke-EmaSyncCompaniesExperimental {
                             }
                         }  
                     }
-                    if ($LicenseDetails.usage -eq $AutotaskUnits.units) {
+                    if ($ActivatedDevicesPerServiceCount[$ServiceId] - $LicenseDetails.usage -eq $AutotaskUnits.units) {
                              Write-Host("ESET Count matches Autotask Count, no update needed")
                     }
                 } else { 

--- a/mappings.json
+++ b/mappings.json
@@ -1,7 +1,7 @@
 {
     "companyMappings": [
         {
-            "EmaCompanyPublicId": "07d6630b-da37-41ae-9ec5-f3767f1f7a96",
+            "EmaCompanyPublicId": "b3991cba-e3a6-45d6-b260-201139220069",
             "AutoTaskContractId": "29684188"
         }, 
         {
@@ -16,6 +16,16 @@
         },
         {
             "EmaLicenseProductCode": 211,
+            "AutotaskServiceId": 17
+        }
+    ],
+    "ProductServiceMappings" : [
+        {
+            "EsetProductName": "ESET Endpoint Security for Windows",
+            "AutotaskServiceId": 16
+        },
+        {
+            "EsetProductName": "ESET Inspect",
             "AutotaskServiceId": 17
         }
     ]


### PR DESCRIPTION
Adds "Invoke-EmaSyncCompaniesExperimental" which provides synchronization using "Activated Devices" data instead of general license data. this allows mapping services based on installed product.. e.g. "ESET Server Security for Windows"  vs "ESET Endpoint Security for Windows" 